### PR TITLE
Ensure videos get mp4 extension

### DIFF
--- a/scripts/ownyourgram-cron.php
+++ b/scripts/ownyourgram-cron.php
@@ -135,7 +135,7 @@ foreach($users as $user) {
             $filename = download_file($entry['photo']);
 
             if(isset($entry['video'])) {
-              $video_filename = download_file($entry['video']);
+              $video_filename = download_file($entry['video'],'mp4');
             } else {
               $video_filename = false;
             }


### PR DESCRIPTION
Videos from instagram are .mp4 this was sending videos to my endpoint as .jpg