### PR TITLE
Feature/can send syndication in resend

### DIFF
--- a/controllers/controllers.php
+++ b/controllers/controllers.php
@@ -360,6 +360,20 @@ $app->post('/instagram/test.json', function() use($app) {
       }
     }
 
+    // Build syndication links for post-again
+    if(isset($_POST['syndicate']) && $_POST['syndicate'] == 'true') {
+      $rules = ORM::for_table('syndication_rules')->where('user_id', $user->id)->find_many();
+      $syndications = '';
+      foreach($rules as $rule) {
+        if($rule->match == '*' || stripos($entry['content'], $rule->match) !== false) {
+          if(!isset($entry['mp-syndicate-to']))
+            $entry['mp-syndicate-to'] = [];
+          $entry['mp-syndicate-to'][] = $rule->syndicate_to;
+          $syndications .= ' +'.$rule->syndicate_to_name;
+        }
+      }
+    }
+
     // Now send to the micropub endpoint
     $response = micropub_post($user, $entry, $filename, $video_filename);
 

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -39,6 +39,6 @@ CREATE TABLE `photos` (
   `published` datetime DEFAULT NULL,
   `instagram_data` text,
   `canonical_url` varchar(255) DEFAULT NULL,
-  'processed' tinyint(4) NOT NULL DEFAULT 0,
+  `processed` tinyint(4) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/views/photos.php
+++ b/views/photos.php
@@ -56,9 +56,10 @@ function load_photos() {
       $("#instagram_photos_list .error").addClass("hidden");
       $(this).text("Working...");
       var btn = $(this);
-
+      var sendSyndications = btn.siblings("label.checkbox-inline").find("input[type=checkbox]").prop('checked')
       $.post("/instagram/test.json", {
-        id: $(this).data("id")
+        id: $(this).data("id"),
+        syndicate: sendSyndications
       }, function(data){
         $("#instagram_photos_list .btn").removeClass("disabled");
         $("#loading").addClass("hidden");
@@ -100,6 +101,10 @@ $(function(){
       <div class="bottom">
         <div class="error hidden alert alert-warning">There was an error posting the photo!</div>
         <a href="" class="btn btn-success">Post</a>
+        <label class="checkbox-inline">
+          <input type="checkbox" class="" name="syndicate" value="1" checked>
+          Send syndications
+        </label>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The post again button didn't send syndications, i've added a checkbox that defaults to on, to allow the resending of syndications.  I added a checkbox, because I felt there were a couple of valid reasons for not wanting to resend the syndications.

![Screenshot of how it looks](https://puu.sh/xmcyy/db813df465.png)

![lolcommit f9be9e12509](https://user-images.githubusercontent.com/382760/29809329-55bc741c-8cce-11e7-82d7-83ed9d201461.gif)

