### PR TITLE
Use url type for inputs

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -72,7 +72,7 @@
           <li><a href="https://indieauth.com/setup">What's This?</a></li>
         </ul>
         <form action="/auth/start" method="get" class="navbar-form navbar-right">
-          <input type="text" name="me" placeholder="yourdomain.com" class="form-control" />
+          <input type="url" name="me" placeholder="yourdomain.com" class="form-control" autocomplete="url" />
           <button type="submit" class="btn">Sign In</button>
           <input type="hidden" name="redirect_uri" value="https://<?= $_SERVER['SERVER_NAME'] ?>/indieauth" />
         </form>

--- a/views/signin.php
+++ b/views/signin.php
@@ -1,10 +1,10 @@
 
 <form action="/auth/start" method="get">
-  <input type="text" name="me" placeholder="http://me.com" value="" class="form-control"><br>
+  <input type="url" name="me" placeholder="http://me.com" value="" class="form-control" autocomplete="url"><br>
 
   <input type="hidden" name="client_id" value="http://ownyourgram.com">
   <input type="hidden" name="redirect_uri" value="http://ownyourgram.com/auth/callback">
-  
+
   <input type="submit" value="Sign In" class="btn btn-primary">
 </form>
 


### PR DESCRIPTION
This PR adds the [`url` type](https://html.spec.whatwg.org/multipage/input.html#attr-input-type-url-keyword) and an [`autocomplete="url"` attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-url) to the `me` input fields.

Since I often struggle with logging in on my phone while entering my blog’s URL, I thought the browser could help me and others logging in faster by using these attributes.