### PR TITLE
Add missing Bootstrap script to head, fixes #70

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -22,6 +22,7 @@
     <meta name="theme-color" content="#ffffff">
 
     <script src="/js/jquery-1.7.1.min.js"></script>
+    <script src="/js/bootstrap/bootstrap.min.js"></script>
   </head>
 
 <body role="document">

--- a/views/layout.php
+++ b/views/layout.php
@@ -22,7 +22,7 @@
     <meta name="theme-color" content="#ffffff">
 
     <script src="/js/jquery-1.7.1.min.js"></script>
-    <script src="/js/bootstrap/bootstrap.min.js"></script>
+    <script src="/bootstrap/js/bootstrap.min.js"></script>
   </head>
 
 <body role="document">


### PR DESCRIPTION
The Bootstrap script is missing, so the hamburger button does not toggle the collapsed menu.