### PR TITLE
Don't set instagram_img_list unless it's really a multi-post

### DIFF
--- a/controllers/controllers.php
+++ b/controllers/controllers.php
@@ -203,7 +203,7 @@ $app->get('/instagram/photos.json', function() use($app) {
 
           $photo->instagram_data = json_encode($entry);
 
-          if($user->multi_photo && is_array($entry['photo'])) {
+          if($user->multi_photo && is_array($entry['photo']) && (count($entry['photo']) > 1)) {
             $photo->instagram_img_list = json_encode($entry['photo']);
           } else {
             if(is_array($entry['photo'])) $entry['photo'] = $entry['photo'][0];

--- a/scripts/ownyourgram-cron.php
+++ b/scripts/ownyourgram-cron.php
@@ -72,7 +72,7 @@ foreach($users as $user) {
 
         $photo->instagram_data = json_encode($entry);
 
-        if($user->multi_photo && is_array($entry['photo'])) {
+        if($user->multi_photo && is_array($entry['photo']) && (count($entry['photo']) > 1)) {
           $photo->instagram_img_list = json_encode($entry['photo']);
         } else {
           if(is_array($entry['photo'])) $entry['photo'] = $entry['photo'][0];


### PR DESCRIPTION
Only set instagram_img_list when it is a multi-post

So that views are shown correctly in photo feed.

![](https://puu.sh/CjnJq/0ac289bb28.png)